### PR TITLE
Fix OpenCV 4.10+ compatibility for handeye_target_detection

### DIFF
--- a/handeye_target_detection/include/PoseEstimator.h
+++ b/handeye_target_detection/include/PoseEstimator.h
@@ -105,8 +105,8 @@ private:
   };
   Patterns calibration_pattern_;
   std::map<std::string, Patterns> pattern_map_;
-  cv::aruco::PREDEFINED_DICTIONARY_NAME dictionary_;
-  std::map<std::string, cv::aruco::PREDEFINED_DICTIONARY_NAME> disctionary_map_;
+  int dictionary_;  // Changed from PREDEFINED_DICTIONARY_NAME for OpenCV 4.10+ compatibility
+  std::map<std::string, int> disctionary_map_;
   std::string path_;
 };
 

--- a/handeye_target_detection/src/pose_estimator.cpp
+++ b/handeye_target_detection/src/pose_estimator.cpp
@@ -76,7 +76,7 @@ PoseEstimator::PoseEstimator(std::shared_ptr<rclcpp::Node>& node, std::string pa
   disctionary_map_["DICT_7X7_100"] = cv::aruco::DICT_7X7_100;
   disctionary_map_["DICT_7X7_250"] = cv::aruco::DICT_7X7_250;
   disctionary_map_["DICT_7X7_1000"] = cv::aruco::DICT_7X7_1000;
-  std::map<std::string, cv::aruco::PREDEFINED_DICTIONARY_NAME>::iterator it = disctionary_map_.find(dictionary);
+  std::map<std::string, int>::iterator it = disctionary_map_.find(dictionary);
   if (it != disctionary_map_.end())
     dictionary_ = disctionary_map_[dictionary];
   else
@@ -307,9 +307,9 @@ void PoseEstimator::imageCB_ARUCO(const sensor_msgs::msg::Image::ConstSharedPtr&
       cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::MONO8);
 
       // Detect aruco board
-      cv::Ptr<cv::aruco::Dictionary> dictionary = cv::aruco::getPredefinedDictionary(dictionary_);
-      cv::Ptr<cv::aruco::GridBoard> board = cv::aruco::GridBoard::create(width_, height_, aruco_board_marker_size_,
-                                                                         aruco_board_marker_seperation_, dictionary);
+      cv::Ptr<cv::aruco::Dictionary> dictionary = cv::makePtr<cv::aruco::Dictionary>(cv::aruco::getPredefinedDictionary(dictionary_));
+      cv::Ptr<cv::aruco::GridBoard> board = cv::makePtr<cv::aruco::GridBoard>(
+          cv::Size(width_, height_), aruco_board_marker_size_, aruco_board_marker_seperation_, *dictionary);
       std::vector<int> ids;
       std::vector<std::vector<cv::Point2f>> corners;
       cv::aruco::detectMarkers(cv_ptr->image, dictionary, corners, ids);
@@ -368,9 +368,9 @@ void PoseEstimator::imageCB_CHARUCO(const sensor_msgs::msg::Image::ConstSharedPt
       cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::MONO8);
 
       // Detect ChArUco
-      cv::Ptr<cv::aruco::Dictionary> dictionary = cv::aruco::getPredefinedDictionary(dictionary_);
-      cv::Ptr<cv::aruco::CharucoBoard> board = cv::aruco::CharucoBoard::create(
-          width_, height_, charuco_board_square_size_, charuco_board_marker_size_, dictionary);
+      cv::Ptr<cv::aruco::Dictionary> dictionary = cv::makePtr<cv::aruco::Dictionary>(cv::aruco::getPredefinedDictionary(dictionary_));
+      cv::Ptr<cv::aruco::CharucoBoard> board = cv::makePtr<cv::aruco::CharucoBoard>(
+          cv::Size(width_, height_), charuco_board_square_size_, charuco_board_marker_size_, *dictionary);
       cv::Ptr<cv::aruco::DetectorParameters> params_ptr(new cv::aruco::DetectorParameters());
 #if CV_MINOR_VERSION == 2
       params_ptr->doCornerRefinement = true;


### PR DESCRIPTION
## Summary
Fixes compatibility issues with OpenCV 4.10+ API changes in the handeye_target_detection package.

## Changes Made

### 1. Updated Dictionary Type (PoseEstimator.h)
- Changed `cv::aruco::PREDEFINED_DICTIONARY_NAME` to `int`
- OpenCV 4.10+ removed the `PREDEFINED_DICTIONARY_NAME` enum typedef
- The underlying type is now `int` directly

### 2. Updated Board Creation API (pose_estimator.cpp)
- Replaced deprecated `cv::aruco::GridBoard::create()` with constructor + `cv::makePtr<>()`
- Replaced deprecated `cv::aruco::CharucoBoard::create()` with constructor + `cv::makePtr<>()`
- OpenCV 4.10+ changed from factory methods to direct constructors

### 3. Updated Dictionary Creation
- Wrapped dictionaries in `cv::makePtr<>()` for API consistency
- Required because detection/refinement functions expect `cv::Ptr<>` types

## API Changes Summary

**Before (OpenCV 4.6-4.9):**
```cpp
cv::Ptr<cv::aruco::GridBoard> board = cv::aruco::GridBoard::create(width, height, size, sep, dict);
```

**After (OpenCV 4.10+):**
```cpp
cv::Ptr<cv::aruco::GridBoard> board = cv::makePtr<cv::aruco::GridBoard>(
    cv::Size(width, height), size, sep, *dict);
```

## Testing
- Tested with OpenCV 4.10.0 and 4.11.0
- Successfully builds with ROS 2 Jazzy on both x64 and Jetson ARM64
- Aruco marker detection working correctly

## Related
- kinisi-robotics/kinisi_ros PR for unified OpenCV versioning across platforms